### PR TITLE
fix for issues 2, 3, and 8

### DIFF
--- a/aacdec.go
+++ b/aacdec.go
@@ -1,43 +1,42 @@
-
 package codec
 
 import (
 	/*
-	#include <libavcodec/avcodec.h>
-	#include <libavutil/avutil.h>
-	#include <string.h>
-	#include <stdio.h>
+		#include <libavcodec/avcodec.h>
+		#include <libavutil/avutil.h>
+		#include <string.h>
+		#include <stdio.h>
 
-	typedef struct {
-		AVCodec *c;
-		AVCodecContext *ctx;
-		AVFrame *f;
-		int got;
-	} aacdec_t ;
+		typedef struct {
+			AVCodec *c;
+			AVCodecContext *ctx;
+			AVFrame *f;
+			int got;
+		} aacdec_t ;
 
-	static int aacdec_new(aacdec_t *m, uint8_t *buf, int len) {
-		m->c = avcodec_find_decoder(CODEC_ID_AAC);
-		m->ctx = avcodec_alloc_context3(m->c);
-		m->f = avcodec_alloc_frame();
-		m->ctx->extradata = buf;
-		m->ctx->extradata_size = len;
-		m->ctx->debug = 0x3;
-		av_log(m->ctx, AV_LOG_DEBUG, "m %p\n", m);
-		return avcodec_open2(m->ctx, m->c, 0);
-	}
+		static int aacdec_new(aacdec_t *m, uint8_t *buf, int len) {
+			m->c = avcodec_find_decoder(CODEC_ID_AAC);
+			m->ctx = avcodec_alloc_context3(m->c);
+			m->f = avcodec_alloc_frame();
+			m->ctx->extradata = buf;
+			m->ctx->extradata_size = len;
+			m->ctx->debug = 0x3;
+			av_log(m->ctx, AV_LOG_DEBUG, "m %p\n", m);
+			return avcodec_open2(m->ctx, m->c, 0);
+		}
 
-	static int aacdec_decode(aacdec_t *m, uint8_t *data, int len) {
-		AVPacket pkt;
-		av_init_packet(&pkt);
-		pkt.data = data;
-		pkt.size = len;
-		av_log(m->ctx, AV_LOG_DEBUG, "decode %p\n", m);
-		return avcodec_decode_audio4(m->ctx, m->f, &m->got, &pkt);
-	}
+		static int aacdec_decode(aacdec_t *m, uint8_t *data, int len) {
+			AVPacket pkt;
+			av_init_packet(&pkt);
+			pkt.data = data;
+			pkt.size = len;
+			av_log(m->ctx, AV_LOG_DEBUG, "decode %p\n", m);
+			return avcodec_decode_audio4(m->ctx, m->f, &m->got, &pkt);
+		}
 	*/
 	"C"
-	"unsafe"
 	"errors"
+	"unsafe"
 )
 
 type AACDecoder struct {
@@ -70,7 +69,7 @@ func (m *AACDecoder) Decode(data []byte) (sample []byte, err error) {
 		err = errors.New("no data")
 		return
 	}
-	size := int(m.m.f.linesize[0])*2
+	size := int(m.m.f.linesize[0]) * 2
 	sample = make([]byte, size*2)
 	for i := 0; i < 2; i++ {
 		C.memcpy(
@@ -81,4 +80,3 @@ func (m *AACDecoder) Decode(data []byte) (sample []byte, err error) {
 	}
 	return
 }
-

--- a/aacdec.go
+++ b/aacdec.go
@@ -17,7 +17,7 @@ import (
 		static int aacdec_new(aacdec_t *m, uint8_t *buf, int len) {
 			m->c = avcodec_find_decoder(CODEC_ID_AAC);
 			m->ctx = avcodec_alloc_context3(m->c);
-			m->f = avcodec_alloc_frame();
+			m->f = av_frame_alloc();
 			m->ctx->extradata = buf;
 			m->ctx->extradata_size = len;
 			m->ctx->debug = 0x3;

--- a/aacenc.go
+++ b/aacenc.go
@@ -1,56 +1,55 @@
-
 package codec
 
 import (
 	/*
-	#include <libavcodec/avcodec.h>
-	#include <libavutil/avutil.h>
-	#include <string.h>
+			#include <libavcodec/avcodec.h>
+			#include <libavutil/avutil.h>
+			#include <string.h>
 
-	typedef struct {
-		AVCodec *c;
-		AVCodecContext *ctx;
-		AVFrame *f;
-		int got;
-		uint8_t buf[1024*10]; int size;
-		int samplerate; int bitrate;
-		int channels;
-	} aacenc_t ;
+			typedef struct {
+				AVCodec *c;
+				AVCodecContext *ctx;
+				AVFrame *f;
+				int got;
+				uint8_t buf[1024*10]; int size;
+				int samplerate; int bitrate;
+				int channels;
+			} aacenc_t ;
 
-	static int aacenc_new(aacenc_t *m) {
-		m->c = avcodec_find_encoder(CODEC_ID_AAC);
-		m->ctx = avcodec_alloc_context3(m->c);
-		m->ctx->sample_fmt = AV_SAMPLE_FMT_FLTP;
-		m->ctx->sample_rate = m->samplerate;
-		m->ctx->bit_rate = m->bitrate;
-		m->ctx->channels = m->channels;
-  	m->ctx->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
-		m->f = avcodec_alloc_frame();
-		int r = avcodec_open2(m->ctx, m->c, 0);
-		av_log(m->ctx, AV_LOG_DEBUG, "extra %d\n", m->ctx->extradata_size);
-		return r;
-	}
+			static int aacenc_new(aacenc_t *m) {
+				m->c = avcodec_find_encoder(CODEC_ID_AAC);
+				m->ctx = avcodec_alloc_context3(m->c);
+				m->ctx->sample_fmt = AV_SAMPLE_FMT_FLTP;
+				m->ctx->sample_rate = m->samplerate;
+				m->ctx->bit_rate = m->bitrate;
+				m->ctx->channels = m->channels;
+		  	m->ctx->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
+				m->f = avcodec_alloc_frame();
+				int r = avcodec_open2(m->ctx, m->c, 0);
+				av_log(m->ctx, AV_LOG_DEBUG, "extra %d\n", m->ctx->extradata_size);
+				return r;
+			}
 
-	static void aacenc_encode(aacenc_t *m) {
-		AVPacket pkt;
-		av_init_packet(&pkt);
-		pkt.data = m->buf;
-		pkt.size = sizeof(m->buf);
-		m->f->nb_samples = 1024;
-		m->f->extended_data = m->f->data;
-		m->f->linesize[0] = 4096;
-		avcodec_encode_audio2(m->ctx, &pkt, m->f, &m->got);
-		av_log(m->ctx, AV_LOG_DEBUG, "got %d size %d\n", m->got, pkt.size);
-		m->size = pkt.size;
-	}
+			static void aacenc_encode(aacenc_t *m) {
+				AVPacket pkt;
+				av_init_packet(&pkt);
+				pkt.data = m->buf;
+				pkt.size = sizeof(m->buf);
+				m->f->nb_samples = 1024;
+				m->f->extended_data = m->f->data;
+				m->f->linesize[0] = 4096;
+				avcodec_encode_audio2(m->ctx, &pkt, m->f, &m->got);
+				av_log(m->ctx, AV_LOG_DEBUG, "got %d size %d\n", m->got, pkt.size);
+				m->size = pkt.size;
+			}
 	*/
 	"C"
-	"unsafe"
 	"errors"
+	"unsafe"
 )
 
 type AACEncoder struct {
-	m C.aacenc_t
+	m      C.aacenc_t
 	Header []byte
 }
 
@@ -90,4 +89,3 @@ func (m *AACEncoder) Encode(sample []byte) (ret []byte, err error) {
 	)
 	return
 }
-

--- a/aacenc.go
+++ b/aacenc.go
@@ -24,7 +24,7 @@ import (
 				m->ctx->bit_rate = m->bitrate;
 				m->ctx->channels = m->channels;
 		  	m->ctx->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
-				m->f = avcodec_alloc_frame();
+				m->f = av_frame_alloc();
 				int r = avcodec_open2(m->ctx, m->c, 0);
 				av_log(m->ctx, AV_LOG_DEBUG, "extra %d\n", m->ctx->extradata_size);
 				return r;

--- a/h264dec.go
+++ b/h264dec.go
@@ -16,7 +16,7 @@ import (
 		static int h264dec_new(h264dec_t *h, uint8_t *data, int len) {
 			h->c = avcodec_find_decoder(CODEC_ID_H264);
 			h->ctx = avcodec_alloc_context3(h->c);
-			h->f = avcodec_alloc_frame();
+			h->f = av_frame_alloc();
 			h->ctx->extradata = data;
 			h->ctx->extradata_size = len;
 			h->ctx->debug = 0x3;

--- a/h264dec.go
+++ b/h264dec.go
@@ -1,41 +1,40 @@
-
 package codec
 
 import (
 	/*
-	#include <libavcodec/avcodec.h>
-	#include <libavformat/avformat.h>
-	#include <libavutil/avutil.h>
+		#include <libavcodec/avcodec.h>
+		#include <libavformat/avformat.h>
+		#include <libavutil/avutil.h>
 
-	typedef struct {
-		AVCodec *c;
-		AVCodecContext *ctx;
-		AVFrame *f;
-		int got;
-	} h264dec_t ;
+		typedef struct {
+			AVCodec *c;
+			AVCodecContext *ctx;
+			AVFrame *f;
+			int got;
+		} h264dec_t ;
 
-	static int h264dec_new(h264dec_t *h, uint8_t *data, int len) {
-		h->c = avcodec_find_decoder(CODEC_ID_H264);
-		h->ctx = avcodec_alloc_context3(h->c);
-		h->f = avcodec_alloc_frame();
-		h->ctx->extradata = data;
-		h->ctx->extradata_size = len;
-		h->ctx->debug = 0x3;
-		return avcodec_open2(h->ctx, h->c, 0);
-	}
+		static int h264dec_new(h264dec_t *h, uint8_t *data, int len) {
+			h->c = avcodec_find_decoder(CODEC_ID_H264);
+			h->ctx = avcodec_alloc_context3(h->c);
+			h->f = avcodec_alloc_frame();
+			h->ctx->extradata = data;
+			h->ctx->extradata_size = len;
+			h->ctx->debug = 0x3;
+			return avcodec_open2(h->ctx, h->c, 0);
+		}
 
-	static int h264dec_decode(h264dec_t *h, uint8_t *data, int len) {
-		AVPacket pkt;
-		av_init_packet(&pkt);
-		pkt.data = data;
-		pkt.size = len;
-		return avcodec_decode_video2(h->ctx, h->f, &h->got, &pkt);
-	}
+		static int h264dec_decode(h264dec_t *h, uint8_t *data, int len) {
+			AVPacket pkt;
+			av_init_packet(&pkt);
+			pkt.data = data;
+			pkt.size = len;
+			return avcodec_decode_video2(h->ctx, h->f, &h->got, &pkt);
+		}
 	*/
 	"C"
-	"unsafe"
 	"errors"
 	"image"
+	"unsafe"
 )
 
 type H264Decoder struct {
@@ -76,15 +75,14 @@ func (m *H264Decoder) Decode(nal []byte) (f *image.YCbCr, err error) {
 	cs := int(m.m.f.linesize[1])
 
 	f = &image.YCbCr{
-		Y: fromCPtr(unsafe.Pointer(m.m.f.data[0]), ys*h),
-		Cb: fromCPtr(unsafe.Pointer(m.m.f.data[1]), cs*h/2),
-		Cr: fromCPtr(unsafe.Pointer(m.m.f.data[2]), cs*h/2),
-		YStride: ys,
-		CStride: cs,
+		Y:              fromCPtr(unsafe.Pointer(m.m.f.data[0]), ys*h),
+		Cb:             fromCPtr(unsafe.Pointer(m.m.f.data[1]), cs*h/2),
+		Cr:             fromCPtr(unsafe.Pointer(m.m.f.data[2]), cs*h/2),
+		YStride:        ys,
+		CStride:        cs,
 		SubsampleRatio: image.YCbCrSubsampleRatio420,
-		Rect: image.Rect(0, 0, w, h),
+		Rect:           image.Rect(0, 0, w, h),
 	}
 
 	return
 }
-

--- a/h264enc.go
+++ b/h264enc.go
@@ -1,56 +1,55 @@
-
 package codec
 
 import (
 
 	/*
-	#include <stdio.h>
-	#include <stdlib.h>
-	#include <stdint.h>
-	#include <string.h>
-	#include <libavcodec/avcodec.h>
-	#include <libavformat/avformat.h>
-	#include <libavutil/avutil.h>
+		#include <stdio.h>
+		#include <stdlib.h>
+		#include <stdint.h>
+		#include <string.h>
+		#include <libavcodec/avcodec.h>
+		#include <libavformat/avformat.h>
+		#include <libavutil/avutil.h>
 
-	typedef struct {
-		int w, h;
-		int pixfmt;
-		char *preset[2];
-		char *profile;
-		int bitrate;
-		int got;
-		AVCodec *c;
-		AVCodecContext *ctx;
-		AVFrame *f;
-		AVPacket pkt;
-	} h264enc_t;
+		typedef struct {
+			int w, h;
+			int pixfmt;
+			char *preset[2];
+			char *profile;
+			int bitrate;
+			int got;
+			AVCodec *c;
+			AVCodecContext *ctx;
+			AVFrame *f;
+			AVPacket pkt;
+		} h264enc_t;
 
-	static int h264enc_new(h264enc_t *m) {
-		m->c = avcodec_find_encoder(CODEC_ID_H264);
-		m->ctx = avcodec_alloc_context3(m->c);
-		m->ctx->width = m->w;
-		m->ctx->height = m->h;
-		m->ctx->bit_rate = m->bitrate;
-		m->ctx->pix_fmt = m->pixfmt;
-		m->ctx->flags |= CODEC_FLAG_GLOBAL_HEADER;
-		m->f = avcodec_alloc_frame();
-		return avcodec_open2(m->ctx, m->c, NULL);
-	}
+		static int h264enc_new(h264enc_t *m) {
+			m->c = avcodec_find_encoder(CODEC_ID_H264);
+			m->ctx = avcodec_alloc_context3(m->c);
+			m->ctx->width = m->w;
+			m->ctx->height = m->h;
+			m->ctx->bit_rate = m->bitrate;
+			m->ctx->pix_fmt = m->pixfmt;
+			m->ctx->flags |= CODEC_FLAG_GLOBAL_HEADER;
+			m->f = avcodec_alloc_frame();
+			return avcodec_open2(m->ctx, m->c, NULL);
+		}
 
 	*/
 	"C"
-	"unsafe"
-	"image"
 	"errors"
+	"image"
 	"strings"
+	"unsafe"
 	//"log"
 )
 
 type H264Encoder struct {
-	m C.h264enc_t
+	m      C.h264enc_t
 	Header []byte
 	Pixfmt image.YCbCrSubsampleRatio
-	W, H int
+	W, H   int
 }
 
 func NewH264Encoder(
@@ -94,7 +93,7 @@ func NewH264Encoder(
 
 type h264Out struct {
 	Data []byte
-	Key bool
+	Key  bool
 }
 
 func (m *H264Encoder) Encode(img *image.YCbCr) (out h264Out, err error) {
@@ -111,12 +110,12 @@ func (m *H264Encoder) Encode(img *image.YCbCr) (out h264Out, err error) {
 			return
 		}
 		f = m.m.f
-		f.data[0] = (*C.uint8_t)(unsafe.Pointer(&img.Y[0]));
-		f.data[1] = (*C.uint8_t)(unsafe.Pointer(&img.Cb[0]));
-		f.data[2] = (*C.uint8_t)(unsafe.Pointer(&img.Cr[0]));
-		f.linesize[0] = (C.int)(img.YStride);
-		f.linesize[1] = (C.int)(img.CStride);
-		f.linesize[2] = (C.int)(img.CStride);
+		f.data[0] = (*C.uint8_t)(unsafe.Pointer(&img.Y[0]))
+		f.data[1] = (*C.uint8_t)(unsafe.Pointer(&img.Cb[0]))
+		f.data[2] = (*C.uint8_t)(unsafe.Pointer(&img.Cr[0]))
+		f.linesize[0] = (C.int)(img.YStride)
+		f.linesize[1] = (C.int)(img.CStride)
+		f.linesize[2] = (C.int)(img.CStride)
 	}
 
 	C.av_init_packet(&m.m.pkt)
@@ -130,7 +129,7 @@ func (m *H264Encoder) Encode(img *image.YCbCr) (out h264Out, err error) {
 		err = errors.New("no picture")
 		return
 	}
-	if (m.m.pkt.size == 0) {
+	if m.m.pkt.size == 0 {
 		err = errors.New("packet size == 0")
 		return
 	}
@@ -145,4 +144,3 @@ func (m *H264Encoder) Encode(img *image.YCbCr) (out h264Out, err error) {
 
 	return
 }
-

--- a/h264enc.go
+++ b/h264enc.go
@@ -32,7 +32,7 @@ import (
 			m->ctx->bit_rate = m->bitrate;
 			m->ctx->pix_fmt = m->pixfmt;
 			m->ctx->flags |= CODEC_FLAG_GLOBAL_HEADER;
-			m->f = avcodec_alloc_frame();
+			m->f = av_frame_alloc();
 			return avcodec_open2(m->ctx, m->c, NULL);
 		}
 

--- a/util.go
+++ b/util.go
@@ -1,4 +1,3 @@
-
 /*
 
 Golang h264,aac decoder/encoder libav wrapper
@@ -19,19 +18,19 @@ Golang h264,aac decoder/encoder libav wrapper
 package codec
 
 import (
-	"unsafe"
 	"reflect"
+	"unsafe"
 
 	/*
-	#cgo darwin LDFLAGS: -lavformat -lavutil -lavcodec 
+		#cgo LDFLAGS: -lavformat -lavutil -lavcodec
 
-	#include <libavutil/avutil.h>
-	#include <libavformat/avformat.h>
+		#include <libavutil/avutil.h>
+		#include <libavformat/avformat.h>
 
-	static void libav_init() {
-		av_register_all();
-		av_log_set_level(AV_LOG_DEBUG);
-	}
+		static void libav_init() {
+			av_register_all();
+			av_log_set_level(AV_LOG_DEBUG);
+		}
 	*/
 	"C"
 )
@@ -47,5 +46,3 @@ func fromCPtr(buf unsafe.Pointer, size int) (ret []uint8) {
 	hdr.Data = uintptr(buf)
 	return
 }
-
-


### PR DESCRIPTION
Removed the 'darwin' from the `#cgo: LDFLAGS` directive so the libav libraries get loaded properly, and changed `avcodec_alloc_frame` calls to `av_frame_alloc` to eliminate warnings about avcodec_alloc_frame being deprecated. This should correct the problems in issues 2, 3, and 8.

The rest of the changes are just gofmt doing its thing.